### PR TITLE
Add Apache2 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2019 Coveo Solutions Inc.
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,15 @@
         "precompile": "npm run build"
     },
     "author": "",
-    "license": "MIT",
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/Coveo-Turbo/counted-tabs#readme",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/Coveo-Turbo/counted-tabs.git"
+    },
+    "bugs": {
+      "url": "https://github.com/Coveo-Turbo/counted-tabs/issues"
+    },
     "devDependencies": {
         "@coveops/cli": "^0.4.0"
     },


### PR DESCRIPTION
Our guidelines are to use Apache-2 license for new Open Source projects: 
https://coveord.atlassian.net/wiki/spaces/RD/pages/96716095/Creating+a+new+Open+Source+Repository

I created the LICENSE file and added Repo info in package.json so it shows up too in NPM. 

License & Repo info should be part of every component in Coveo Turbo.
